### PR TITLE
removed old not-needed data from home in nav

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -24,7 +24,7 @@
         <ul class="navbar-nav">
           <!-- home -->
           <li class="nav-item ms-3">
-            <a class="nav-link" aria-current="page" href="/"><i class="bi bi-house-door"></i> Home</a>
+            <a class="nav-link" href="/"><i class="bi bi-house-door"></i> Home</a>
           </li>
           <!-- dashboard  -->
           <li class="nav-item ms-3">


### PR DESCRIPTION
Just a small change because the link to home had a field leftover from when I copied it from a Bootstrap example, we don't use it